### PR TITLE
Handle bad version numbers gracefully

### DIFF
--- a/getcluster
+++ b/getcluster
@@ -22,6 +22,7 @@ import struct
 from optparse import OptionParser
 
 cluster_re = re.compile('^\S+ \S+( \S+){0,2}$')
+version_re = re.compile('^(\d+)(?:\.(\d+)){0,1}')
 debugMode = os.getenv('DEBUG_GETCLUSTER', 'no') == 'yes'
 
 def debug(msg, *args):
@@ -42,8 +43,8 @@ def cleanup(l):
     return filter(lambda x: cluster_re.match(x), map(lambda x: x.rstrip(), l))
 
 def vercmp(v1, v2):
-    v1l = map(int, map(lambda x: 0 if x is None else x, re.search('^(\d+)(?:\.(\d+)){0,1}',v1).groups()))
-    v2l = map(int, map(lambda x: 0 if x is None else x, re.search('^(\d+)(?:\.(\d+)){0,1}',v2).groups()))
+    v1l = map(int, map(lambda x: 0 if x is None else x, version_re.search(v1).groups()))
+    v2l = map(int, map(lambda x: 0 if x is None else x, version_re.search(v2).groups()))
     return cmp(v1l, v2l)
 
 
@@ -72,6 +73,9 @@ def main():
         args.pop(0)
     if len(args) != 1:
         parser.print_usage()
+        return 1
+    if version_re.search(args[0]) is None:
+        perror("Invalid version number: %s", args[0])
         return 1
     
     if options.deprecated:

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from distutils.core import setup
 
 setup(name='getcluster',
-      version='10.2.1',
+      version='10.2.2',
       author='Debathena Project',
       author_email='debathena@mit.edu',
       scripts=['getcluster'],


### PR DESCRIPTION
Pre-compile the regexp for a valid version number, and check
args[0] against it before it fails later in vercmp().  Note that
we could easily use .match() instead of .search(), since the regexp
has a start-of-line anchor in it, but this is a bit more verbose.
